### PR TITLE
feat: implement spacing token system and card components

### DIFF
--- a/docs/spacing-system.md
+++ b/docs/spacing-system.md
@@ -1,0 +1,91 @@
+# Spacing Token System
+
+This project uses a consistent spacing system based on 4px and 8px increments, following design system best practices.
+
+## Base Spacing Tokens
+
+All spacing values are based on 4px increments:
+
+| Token | Value | Pixels | Usage |
+|-------|-------|--------|-------|
+| `--spacing-xs` | 0.25rem | 4px | Minimal spacing, borders |
+| `--spacing-sm` | 0.5rem | 8px | Small element spacing |
+| `--spacing-md` | 0.75rem | 12px | Component spacing |
+| `--spacing-lg` | 1rem | 16px | Section spacing |
+| `--spacing-xl` | 1.25rem | 20px | Large element spacing |
+| `--spacing-2xl` | 1.5rem | 24px | Content padding |
+| `--spacing-3xl` | 2rem | 32px | Large section spacing |
+| `--spacing-4xl` | 2.5rem | 40px | Extra large spacing |
+| `--spacing-5xl` | 3rem | 48px | Page-level spacing |
+| `--spacing-6xl` | 4rem | 64px | Maximum spacing |
+
+## Semantic Spacing Tokens
+
+For consistent usage across components:
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--section-spacing` | 16px | Space between major sections |
+| `--content-padding` | 24px | Padding for content areas |
+| `--card-padding` | 24px | Padding inside cards |
+| `--element-spacing` | 8px | Space between small elements |
+| `--component-spacing` | 12px | Space between components |
+
+## Tailwind Classes
+
+These tokens are available as Tailwind classes:
+
+```css
+/* Semantic spacing classes */
+.p-content     /* padding: var(--content-padding) */
+.p-card        /* padding: var(--card-padding) */
+.space-y-section  /* gap: var(--section-spacing) */
+.gap-component    /* gap: var(--component-spacing) */
+.gap-element      /* gap: var(--element-spacing) */
+```
+
+## Usage Examples
+
+### Section Spacing
+```jsx
+// Use space-y-section for consistent spacing between sections
+<div className="space-y-section">
+  <section>...</section>
+  <section>...</section>
+</div>
+```
+
+### Content Padding
+```jsx
+// Use p-content for main content areas
+<div className="p-content">
+  Content here
+</div>
+```
+
+### Component Spacing
+```jsx
+// Use gap-component for spacing between related components
+<div className="grid grid-cols-2 gap-component">
+  <Card>...</Card>
+  <Card>...</Card>
+</div>
+```
+
+## Best Practices
+
+1. **Always use tokens**: Never use arbitrary spacing values
+2. **Prefer semantic tokens**: Use `--section-spacing` instead of `--spacing-lg` when possible
+3. **Consistent hierarchy**: Larger elements should have larger spacing
+4. **Mobile considerations**: Spacing may need to be reduced on smaller screens
+
+## Migration Guide
+
+When updating existing components:
+
+1. Replace `space-y-12` (48px) with `space-y-section` (16px) for tighter sections
+2. Replace `px-6 py-8` with `p-content` for consistent content padding
+3. Replace `gap-6` with `gap-component` for component grids
+4. Replace `mb-12` with container-level `space-y-section`
+
+This creates a much more professional and consistent spacing system throughout the application.

--- a/src/components/layout/ContentAppLayout.tsx
+++ b/src/components/layout/ContentAppLayout.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from 'react';
-import { motion } from 'framer-motion';
-import { cn } from '@/lib/utils';
+import React, { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
 
 interface ContentAppLayoutProps {
   /** Title for the top bar */
@@ -20,33 +20,33 @@ interface ContentAppLayoutProps {
   /** Additional CSS classes */
   className?: string;
   /** Background color theme */
-  theme?: 'default' | 'blue' | 'green' | 'purple';
+  theme?: "default" | "blue" | "green" | "purple";
 }
 
 const themeStyles = {
   default: {
-    bg: 'bg-background',
-    border: 'border-border',
-    text: 'text-foreground',
-    accent: 'bg-accent',
+    bg: "bg-background",
+    border: "border-border",
+    text: "text-foreground",
+    accent: "bg-accent",
   },
   blue: {
-    bg: 'bg-blue-50',
-    border: 'border-blue-200',
-    text: 'text-blue-900',
-    accent: 'bg-blue-100',
+    bg: "bg-blue-50",
+    border: "border-blue-200",
+    text: "text-blue-900",
+    accent: "bg-blue-100",
   },
   green: {
-    bg: 'bg-green-50',
-    border: 'border-green-200',
-    text: 'text-green-900',
-    accent: 'bg-green-100',
+    bg: "bg-green-50",
+    border: "border-green-200",
+    text: "text-green-900",
+    accent: "bg-green-100",
   },
   purple: {
-    bg: 'bg-purple-50',
-    border: 'border-purple-200',
-    text: 'text-purple-900',
-    accent: 'bg-purple-100',
+    bg: "bg-purple-50",
+    border: "border-purple-200",
+    text: "text-purple-900",
+    accent: "bg-purple-100",
   },
 };
 
@@ -59,18 +59,19 @@ export function ContentAppLayout({
   tableOfContents,
   children,
   className,
-  theme = 'default',
+  theme = "default",
 }: ContentAppLayoutProps) {
   const styles = themeStyles[theme];
 
   return (
-    <div className={cn('flex-1 min-h-screen flex flex-col', styles.bg, className)}>
+    <div
+      className={cn("flex-1 min-h-screen flex flex-col", styles.bg, className)}
+    >
       {/* Top Bar - App Header */}
       <motion.header
         className={cn(
-          'border-b px-6 py-4 flex items-center justify-between',
-          styles.border,
-          styles.bg
+          "border-b px-6 py-4 flex items-center justify-between bg-white",
+          styles.border
         )}
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -78,26 +79,18 @@ export function ContentAppLayout({
       >
         <div className="flex items-center gap-4">
           {icon && (
-            <div className={cn('flex-shrink-0', styles.text)}>
-              {icon}
-            </div>
+            <div className={cn("flex-shrink-0", styles.text)}>{icon}</div>
           )}
           <div>
-            <h1 className={cn('text-2xl font-bold', styles.text)}>
-              {title}
-            </h1>
+            <h1 className={cn("text-2xl font-bold", styles.text)}>{title}</h1>
             {subtitle && (
-              <p className={cn('text-sm opacity-70', styles.text)}>
+              <p className={cn("text-sm opacity-70", styles.text)}>
                 {subtitle}
               </p>
             )}
           </div>
         </div>
-        {actions && (
-          <div className="flex items-center gap-2">
-            {actions}
-          </div>
-        )}
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
       </motion.header>
 
       {/* Content Area */}
@@ -105,7 +98,7 @@ export function ContentAppLayout({
         {/* Secondary Navigation (ITS) */}
         {secondaryNav && (
           <motion.aside
-            className={cn('hidden lg:block w-56 border-r', styles.border)}
+            className={cn("hidden lg:block w-56 border-r", styles.border)}
             initial={{ opacity: 0, x: -20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
@@ -122,14 +115,12 @@ export function ContentAppLayout({
           transition={{ duration: 0.3, delay: 0.2 }}
         >
           {/* Content */}
-          <div className="flex-1 overflow-y-auto">
-            {children}
-          </div>
+          <div className="flex-1 overflow-y-auto">{children}</div>
 
           {/* Table of Contents (OTP) */}
           {tableOfContents && (
             <motion.aside
-              className="hidden xl:block w-64 border-l border-border"
+              className="hidden xl:block w-64 border-l border-border bg-white"
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.3, delay: 0.3 }}

--- a/src/components/layout/ContentAppSecondaryNav.tsx
+++ b/src/components/layout/ContentAppSecondaryNav.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { NavLink } from 'react-router-dom';
-import { motion } from 'framer-motion';
-import { cn } from '@/lib/utils';
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
 
 interface NavItem {
   id: string;
@@ -29,13 +29,13 @@ export function ContentAppSecondaryNav({
   return (
     <nav
       className={cn(
-        "sticky top-0 w-full h-full overflow-y-auto bg-background",
+        "sticky top-0 w-full h-full overflow-y-auto bg-white",
         className
       )}
       aria-label="Secondary navigation"
     >
       <div className="px-4 py-6">
-        <motion.h4 
+        <motion.h4
           className="text-sm font-medium text-foreground mb-4 px-2"
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -43,15 +43,15 @@ export function ContentAppSecondaryNav({
         >
           {title}
         </motion.h4>
-        
-        <motion.ul 
+
+        <motion.ul
           className="space-y-1"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.3, delay: 0.1 }}
         >
           {items.map((item, index) => (
-            <motion.li 
+            <motion.li
               key={item.id}
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -59,8 +59,8 @@ export function ContentAppSecondaryNav({
             >
               <NavLink
                 to={item.path}
-                target={item.isExternal ? '_blank' : undefined}
-                rel={item.isExternal ? 'noopener noreferrer' : undefined}
+                target={item.isExternal ? "_blank" : undefined}
+                rel={item.isExternal ? "noopener noreferrer" : undefined}
                 className={({ isActive }) =>
                   cn(
                     "flex items-center gap-3 py-2 px-2 text-sm transition-colors rounded-md group",
@@ -71,9 +71,7 @@ export function ContentAppSecondaryNav({
                 }
               >
                 {item.icon && (
-                  <span className="flex-shrink-0 w-4 h-4">
-                    {item.icon}
-                  </span>
+                  <span className="flex-shrink-0 w-4 h-4">{item.icon}</span>
                 )}
                 <span className="flex-1">{item.title}</span>
                 {item.badge && (
@@ -83,7 +81,12 @@ export function ContentAppSecondaryNav({
                 )}
                 {item.isExternal && (
                   <span className="flex-shrink-0 w-3 h-3 opacity-50">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
                       <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
                       <polyline points="15,3 21,3 21,9" />
                       <line x1="10" y1="14" x2="21" y2="3" />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,25 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
+
+    /* Spacing Token System - Based on 4px/8px increments */
+    --spacing-xs: 0.25rem; /* 4px */
+    --spacing-sm: 0.5rem; /* 8px */
+    --spacing-md: 0.75rem; /* 12px */
+    --spacing-lg: 1rem; /* 16px */
+    --spacing-xl: 1.25rem; /* 20px */
+    --spacing-2xl: 1.5rem; /* 24px */
+    --spacing-3xl: 2rem; /* 32px */
+    --spacing-4xl: 2.5rem; /* 40px */
+    --spacing-5xl: 3rem; /* 48px */
+    --spacing-6xl: 4rem; /* 64px */
+
+    /* Semantic Spacing Tokens */
+    --section-spacing: var(--spacing-lg); /* 16px between sections */
+    --content-padding: var(--spacing-2xl); /* 24px for content padding */
+    --card-padding: var(--spacing-2xl); /* 24px for card padding */
+    --element-spacing: var(--spacing-sm); /* 8px for small element spacing */
+    --component-spacing: var(--spacing-md); /* 12px for component spacing */
   }
   .dark {
     --background: 0 0% 3.9%;

--- a/src/pages/UniformsPage.tsx
+++ b/src/pages/UniformsPage.tsx
@@ -5,6 +5,13 @@ import { ContentAppSecondaryNav } from "../components/layout/ContentAppSecondary
 import TableOfContents from "../components/TableOfContents";
 import { motion } from "framer-motion";
 import WorkIcon from "@mui/icons-material/Work";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "../components/ui/card";
 
 // Navigation items for the uniforms section
 const uniformsNavItems = [
@@ -58,75 +65,93 @@ const UniformsPage = () => {
       >
         {/* Content Area */}
         <motion.div
-          className="px-6 py-8"
+          className="p-content"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          <div className="max-w-4xl mx-auto space-y-12">
-            <section id="overview" className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-6">
-                Welcome to Employee Uniforms
-              </h2>
-              <p className="text-lg text-muted-foreground mb-6">
-                Welcome to the United Airlines uniform program. Here you'll find
-                everything you need to know about ordering, maintaining, and
-                wearing your uniform.
-              </p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="p-6 border rounded-lg">
-                  <h3 className="text-xl font-semibold mb-3">Quick Start</h3>
-                  <p className="text-muted-foreground">
-                    New to the uniform program? Start here for essential
-                    information.
-                  </p>
-                </div>
-                <div className="p-6 border rounded-lg">
-                  <h3 className="text-xl font-semibold mb-3">Order Status</h3>
-                  <p className="text-muted-foreground">
-                    Track your current uniform orders and delivery status.
-                  </p>
-                </div>
-              </div>
+          <div className="max-w-4xl mx-auto space-y-section">
+            <section id="overview">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-3xl">
+                    Welcome to Employee Uniforms
+                  </CardTitle>
+                  <CardDescription className="text-lg">
+                    Welcome to the United Airlines uniform program. Here you'll
+                    find everything you need to know about ordering,
+                    maintaining, and wearing your uniform.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-component">
+                    <Card>
+                      <CardHeader>
+                        <CardTitle className="text-xl">Quick Start</CardTitle>
+                        <CardDescription>
+                          New to the uniform program? Start here for essential
+                          information.
+                        </CardDescription>
+                      </CardHeader>
+                    </Card>
+                    <Card>
+                      <CardHeader>
+                        <CardTitle className="text-xl">Order Status</CardTitle>
+                        <CardDescription>
+                          Track your current uniform orders and delivery status.
+                        </CardDescription>
+                      </CardHeader>
+                    </Card>
+                  </div>
+                </CardContent>
+              </Card>
             </section>
 
-            <section id="customer-service" className="mb-12">
-              <h2 className="text-2xl font-semibold text-foreground mb-6">
-                Customer Service Uniforms
-              </h2>
-              <p className="text-muted-foreground">
-                Information about customer service uniform requirements and
-                options.
-              </p>
+            <section id="customer-service">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Customer Service Uniforms</CardTitle>
+                  <CardDescription>
+                    Information about customer service uniform requirements and
+                    options.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
             </section>
 
-            <section id="flight-attendants" className="mb-12">
-              <h2 className="text-2xl font-semibold text-foreground mb-6">
-                Flight Attendant Uniforms
-              </h2>
-              <p className="text-muted-foreground">
-                Comprehensive guide to flight attendant uniform standards and
-                care.
-              </p>
+            <section id="flight-attendants">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Flight Attendant Uniforms</CardTitle>
+                  <CardDescription>
+                    Comprehensive guide to flight attendant uniform standards
+                    and care.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
             </section>
 
-            <section id="pilots" className="mb-12">
-              <h2 className="text-2xl font-semibold text-foreground mb-6">
-                Pilot Uniforms
-              </h2>
-              <p className="text-muted-foreground">
-                Pilot uniform specifications, insignia, and maintenance
-                guidelines.
-              </p>
+            <section id="pilots">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Pilot Uniforms</CardTitle>
+                  <CardDescription>
+                    Pilot uniform specifications, insignia, and maintenance
+                    guidelines.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
             </section>
 
-            <section id="faq" className="mb-12">
-              <h2 className="text-2xl font-semibold text-foreground mb-6">
-                Frequently Asked Questions
-              </h2>
-              <p className="text-muted-foreground">
-                Common questions and answers about the uniform program.
-              </p>
+            <section id="faq">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Frequently Asked Questions</CardTitle>
+                  <CardDescription>
+                    Common questions and answers about the uniform program.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
             </section>
           </div>
         </motion.div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,89 +1,89 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-    darkMode: ['class'],
-    content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: ["class"],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-  	extend: {
-  		fontFamily: {
-  			sans: [
-  				'Inter',
-  				'system-ui',
-  				'sans-serif'
-  			]
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "system-ui", "sans-serif"],
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          1: "hsl(var(--chart-1))",
+          2: "hsl(var(--chart-2))",
+          3: "hsl(var(--chart-3))",
+          4: "hsl(var(--chart-4))",
+          5: "hsl(var(--chart-5))",
+        },
+      },
+      spacing: {
+        section: "var(--section-spacing)",
+        content: "var(--content-padding)",
+        card: "var(--card-padding)",
+        element: "var(--element-spacing)",
+        component: "var(--component-spacing)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "var(--radix-accordion-content-height)",
+          },
+        },
+        "accordion-up": {
+          from: {
+            height: "var(--radix-accordion-content-height)",
+          },
+          to: {
+            height: "0",
+          },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-      require("tailwindcss-animate")
-],
+  plugins: [require("@tailwindcss/typography"), require("tailwindcss-animate")],
 };


### PR DESCRIPTION
- Add comprehensive spacing token system based on 4px/8px increments
- Create shadcn Card component with proper styling and accessibility
- Update uniforms page to use Card components for all content sections
- Implement tighter, more professional spacing (16px vs 48px between sections)
- Add white backgrounds to OTP menu, ITS menu, and top section bar
- Create semantic spacing tokens for consistent design system
- Add Tailwind integration for spacing tokens
- Include comprehensive documentation in docs/spacing-system.md

This creates a much more professional and scannable layout while maintaining excellent readability and establishing a scalable design system.